### PR TITLE
add functional nn ops

### DIFF
--- a/docs/api/tinygrad/nn/__init__.md
+++ b/docs/api/tinygrad/nn/__init__.md
@@ -1,0 +1,7 @@
+# [nn/`__init__`.py](/tinygrad/nn/__init__.py)
+
+## class `LayerNorm(normalized_shape:Union[int, Tuple[int, ...]], eps:float=1e-5, elementwise_affine:bool=True)`
+
+## class `LayerNorm2d(normalized_shape:Union[int, Tuple[int, ...]], eps:float=1e-5, elementwise_affine:bool=True)`
+
+## class `BatchNorm2d(sz, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1)`

--- a/docs/api/tinygrad/tensor.md
+++ b/docs/api/tinygrad/tensor.md
@@ -676,3 +676,44 @@ print(t.linear(w, b).numpy()) #->
  [ 1.9292889  -1.3569635  -0.12129784]]
 """
 ```
+
+#### `.sequential(self, ll:List[Callable[[Tensor], Tensor]])`
+
+Applies a list of Tensor self-defined transformations to the current tensor.
+
+```python
+t = Tensor.arange(9)
+
+def add(x:Tensor) -> Tensor:
+  return x+1
+
+L = [
+  lambda x: x / 3.0,
+  lambda x: x.reshape((3,3)),
+  lambda x: add(x)
+]
+print(t.sequential(L).numpy()) #->
+"""
+[[1.        1.3333334 1.6666667]
+ [2.        2.3333335 2.6666667]
+ [3.        3.3333335 3.6666667]]
+"""
+```
+
+#### `.layernorm(self, axis=-1, eps:float=1e-5)`
+
+$\begin{aligned}y=\frac{x-E[x]}{\sqrt{Var[x]+\epsilon}}\end{aligned}$
+
+Unless specified, the mean and standard-deviation are calculated over the last dimension.
+
+See `LayerNorm`, `LayerNorm2d` for details
+
+#### `.batchnorm(self, weight:Optional[Tensor], bias:Optional[Tensor], mean:Tensor, invstd:Tensor)`
+
+Applies batch normalization for each channel across a batch of data with 2D inputs
+
+See `Batchnorm2d` for details.
+
+#### `.dropout(self, p=0.5)`
+
+#### `.scaled_dot_product_attention(self, key:Tensor, value:Tensor, attn_mask:Optional[Tensor]=None, dropout_p:float=0.0, is_causal:bool=False)`


### PR DESCRIPTION
So I paused at `.layernorm` and `.batchnorm` cause I feel like there's going to be overlaps between `BatchNorm2d`, `LayerNorm` that's from `nn`. So far my thinking is to make a link to the other md file (`__init__.py`) and just add examples there. Let me know what you think.